### PR TITLE
Compiler compatability

### DIFF
--- a/Radon/include/File.hpp
+++ b/Radon/include/File.hpp
@@ -16,14 +16,14 @@ namespace radon
 
 		File(const std::string & path, bool reading = true);
 
-		std::unique_ptr<Section> getSection(const std::string & name);
+		Section* getSection(const std::string & name);
 
-		void addSection(Section & category);
+		void addSection(const std::string & name);
 
 		void saveToFile();
 
 	private:
-		std::vector<std::unique_ptr<Section>> sections;
+		std::vector<Section> sections;
 		std::string path;
 	};
 }

--- a/Radon/include/Section.hpp
+++ b/Radon/include/Section.hpp
@@ -20,9 +20,9 @@ namespace radon
 
 		Section(const std::string & name);
 
-		Key getKey(const std::string & name);
+		Key *getKey(const std::string & name);
 
-		void addKey(Key & variable);
+		void addKey(Key variable);
 
 	private:
 		std::vector<Key> keys;

--- a/Radon/source/File.cpp
+++ b/Radon/source/File.cpp
@@ -15,7 +15,7 @@ namespace radon
 		this->path = path;
 		if (reading)
 		{
-			std::ifstream stream(path);
+			std::ifstream stream(path.c_str());
 
 			if (stream.is_open())
 			{
@@ -47,15 +47,15 @@ namespace radon
 
 	Section *File::getSection(const std::string & name)
 	{
-		for (auto & section : sections)
+		for (int i = 0; i < (int)sections.size(); i++)
 		{
-			if (section.getName() == name)
+			if (sections[i].getName() == name)
 			{
-				return &section;
+				return &sections[i];
 			}
 		}
 
-		return nullptr;
+		return NULL;
 	}
 
 
@@ -69,12 +69,12 @@ namespace radon
 	{
 		std::ofstream file(path.data(), std::ios::out | std::ios::trunc);
 
-		for (auto & section : sections)
+		for (int i = 0; i < (int)sections.size(); i++)
 		{
-			file << "[" << section.getName() << "] \n";
-			for (auto & key : section.keys)
+			file << "[" << sections[i].getName() << "] \n";
+			for(int j = 0; j < (int)sections[i].keys.size(); j++)
 			{
-				file << key.getName() << "=" << key.getStringValue() << "\n";
+				file << sections[i].keys[j].getName() << "=" << sections[i].keys[j].getStringValue() << "\n";
 			}
 		}
 		file.close();

--- a/Radon/source/File.cpp
+++ b/Radon/source/File.cpp
@@ -24,12 +24,11 @@ namespace radon
 
 				while (std::getline(stream, buffer))
 				{
-					buffer.erase(std::remove(buffer.begin(), buffer.end(), ' '), buffer.end());
 					if (buffer[0] == ';' || buffer[0] == '#') continue;
 					if (buffer[0] == '[')
 					{
 						nameOfCurrent = buffer.substr(buffer.find("[") + 1, buffer.find("]") - 1);
-						sections.push_back(std::unique_ptr<Section>(new Section(nameOfCurrent)));
+						sections.push_back(Section(nameOfCurrent));
 					}
 					else
 					{
@@ -38,7 +37,7 @@ namespace radon
 						std::string nameOfElement = buffer.substr(0, equalsPosition);
 						std::string valueOfElement = buffer.substr(equalsPosition + 1, buffer.size());
 
-						sections.back()->addKey(Key(nameOfElement, valueOfElement));
+						sections.back().addKey(Key(nameOfElement, valueOfElement));
 					}
 				}
 			}
@@ -46,23 +45,23 @@ namespace radon
 	}
 
 
-	std::unique_ptr<Section> File::getSection(const std::string & name)
+	Section *File::getSection(const std::string & name)
 	{
 		for (auto & section : sections)
 		{
-			if (section->getName() == name)
+			if (section.getName() == name)
 			{
-				return std::make_unique<Section>(*section);
+				return &section;
 			}
 		}
 
-		assert(1);
+		return nullptr;
 	}
 
 
-	void File::addSection(Section & category)
+	void File::addSection(const std::string & name)
 	{
-		sections.push_back(std::make_unique<Section>(category));
+		sections.push_back(Section(name));
 	}
 
 
@@ -72,8 +71,8 @@ namespace radon
 
 		for (auto & section : sections)
 		{
-			file << "[" << section->getName() << "] \n";
-			for (auto & key : section->keys)
+			file << "[" << section.getName() << "] \n";
+			for (auto & key : section.keys)
 			{
 				file << key.getName() << "=" << key.getStringValue() << "\n";
 			}

--- a/Radon/source/Key.cpp
+++ b/Radon/source/Key.cpp
@@ -1,6 +1,15 @@
 // Copyright Dmitro bjornus Szewczuk 2017
 
 #include "../include/Radon.hpp"
+#include <sstream>
+
+std::string Float2String(float fVal)
+{
+	std::ostringstream ss;
+	ss << fVal;
+	std::string s(ss.str());
+	return s;
+}
 
 namespace radon
 {
@@ -17,7 +26,7 @@ namespace radon
 
 
 	Key::Key(const std::string & name, const float & value)
-		: Named(name), value(std::to_string(value))
+		: Named(name), value(Float2String(value))
 	{
 	}
 
@@ -36,7 +45,7 @@ namespace radon
 
 	void Key::setValue(float & value)
 	{
-		this->value = std::to_string(value);
+		this->value = Float2String(value);
 	}
 
 

--- a/Radon/source/Section.cpp
+++ b/Radon/source/Section.cpp
@@ -20,13 +20,13 @@ namespace radon
 
 	Key *Section::getKey(const std::string & name)
 	{
-		for (auto & key : keys)
+		for (int i = 0; i < (int)keys.size(); i++)
 		{
-			if (key.getName() == name)
-				return &key;
+			if (keys[i].getName() == name)
+				return &keys[i];
 		}
 
-		return nullptr;
+		return NULL;
 	}
 
 

--- a/Radon/source/Section.cpp
+++ b/Radon/source/Section.cpp
@@ -18,20 +18,20 @@ namespace radon
 	}
 
 
-	Key Section::getKey(const std::string & name)
+	Key *Section::getKey(const std::string & name)
 	{
-		for each (auto var in keys)
+		for (auto & key : keys)
 		{
-			if (var.getName() == name)
-				return var;
+			if (key.getName() == name)
+				return &key;
 		}
 
-		assert(1);
+		return nullptr;
 	}
 
 
-	void Section::addKey(Key & variable)
+	void Section::addKey(Key key)
 	{
-		keys.push_back(variable);
+		keys.push_back(key);
 	}
 }


### PR DESCRIPTION
This allows Radon to build under Visual Studio 2003, GCC 7.3. It has also been tested with LLVM 10 and GCC 5.3.